### PR TITLE
Update go-tests.yml

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -26,13 +26,33 @@ permissions:
 
 jobs:
   test-linux:
-    if: github.repository_owner == 'github'
-    name: Test Linux (Ubuntu)
-    runs-on: ubuntu-latest-xl
+    if: github.repository_owner == 'FreeMason9224'
+    name: Test on Ubuntu
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.15, 1.16, 1.17]
     steps:
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
       - name: Check out code
         uses: actions/checkout@v4
-      - name: Run tests
-        uses: ./go/actions/test
+      - name: Cache Go modules
+        uses: actions/cache@v4
         with:
-          run-code-checks: true
+          path: go/pkg/mod
+          key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-${{ matrix.go-version }}-
+            ${{ runner.os }}-go-
+      - name: Install dependencies
+        run: go mod download
+      - name: Run tests
+        run: go test ./...
+      - name: Run code checks
+        run: |
+          if [ "${{ matrix.go-version }}" == "1.17" ]; then
+            go vet ./...
+          fi


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/go-tests.yml` file to improve the CI pipeline for Go tests. The most important changes include modifying the job configuration to support multiple Go versions, adding caching for Go modules, and updating the steps for setting up Go and running tests.

CI pipeline improvements:

* [`.github/workflows/go-tests.yml`](diffhunk://#diff-5a1bcf51eaa62614197dde8c00207b1c6a3c91d08241b0953e600baa7b66f6d7L29-R58): Modified the job configuration to support testing on multiple Go versions (1.15, 1.16, 1.17) using a matrix strategy.
* [`.github/workflows/go-tests.yml`](diffhunk://#diff-5a1bcf51eaa62614197dde8c00207b1c6a3c91d08241b0953e600baa7b66f6d7L29-R58): Added steps to set up Go using `actions/setup-go@v4` and to cache Go modules using `actions/cache@v4`.
* [`.github/workflows/go-tests.yml`](diffhunk://#diff-5a1bcf51eaa62614197dde8c00207b1c6a3c91d08241b0953e600baa7b66f6d7L29-R58): Updated steps to install dependencies with `go mod download`, run tests with `go test ./...`, and conditionally run `go vet` for Go version 1.17.